### PR TITLE
Add camelCase Model Names

### DIFF
--- a/libs/prisma-crud-generator/README.md
+++ b/libs/prisma-crud-generator/README.md
@@ -47,6 +47,18 @@ Additionally, the `prisma-crud-generator` also offers specific configuration par
 | CRUDServiceSuffix | string | "CrudService" | Suffix that is appended to the name of the model.               |
 | CRUDStubFile      | string | undefined     | (optional) path to a custom stub-file to read the template from |
 
+#### CRUD Service Stub File
+
+You can add your own CRUD Service Stub file that contains all custom code. You can use the following variables, that are automatically replaced during the generation process:
+
+| Variable Name             | Description                                                                                            |
+| ------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `#{CrudServiceClassName}` | The generated class name for the service (i.e., based on the parameter for the generator)              |
+| `#{Model}`                | The original model name (i.e., `User`)                                                                 |
+| `#{model}`                | The lowercase version of the model name (i.e., `user`)                                                 |
+| `#{MODEL}`                | The uppercase version of the model name (i.e., `USER`)                                                 |
+| `#{moDel}`                | The camelCased version of the model name (i.e., `userName`). Note that the first letter is lowercased! |
+
 ## Tipps
 
 Note that this package also works in combination with `PrisMerge` (Docs)[https://github.com/prisma-utils/prisma-utils/tree/main/libs/prismerge]

--- a/libs/prisma-crud-generator/src/generators/crud.service.generator.ts
+++ b/libs/prisma-crud-generator/src/generators/crud.service.generator.ts
@@ -46,6 +46,10 @@ export class CrudServiceGenerator {
       /#{model}/g,
       this.model.name.toLowerCase(),
     );
+    crudServiceContent = crudServiceContent.replace(
+      /#{moDel}/g,
+      this.lowerCaseFirstChar(this.model.name),
+    );
 
     return crudServiceContent;
   }
@@ -58,5 +62,9 @@ export class CrudServiceGenerator {
     );
 
     await writeFileSafely(this.config, dtoFilePath, content);
+  }
+
+  private lowerCaseFirstChar(text: string) {
+    return text.charAt(0).toLowerCase() + text.slice(1);
   }
 }

--- a/libs/prisma-crud-generator/src/stubs/crud.service.stub.ts
+++ b/libs/prisma-crud-generator/src/stubs/crud.service.stub.ts
@@ -14,7 +14,7 @@ export class #{CrudServiceClassName} {
 
   async getAll(filter?: Prisma.#{Model}FindManyArgs): Promise<#{Model}[] | null> {
     try {
-      return await this.prismaService.#{model}.findMany(filter);
+      return await this.prismaService.#{moDel}.findMany(filter);
     } catch (e) {
       return null;
     }
@@ -22,7 +22,7 @@ export class #{CrudServiceClassName} {
 
   async getById(id: string): Promise<#{Model} | null> {
     try {
-      return await this.prismaService.#{model}.findUnique({ where: { id: id } });
+      return await this.prismaService.#{moDel}.findUnique({ where: { id: id } });
     } catch (e) {
       return null;
     }
@@ -30,7 +30,7 @@ export class #{CrudServiceClassName} {
 
   async create(data: Prisma.#{Model}CreateInput): Promise<#{Model} | null> {
     try {
-      return await this.prismaService.#{model}.create({ data: data });
+      return await this.prismaService.#{moDel}.create({ data: data });
     } catch (e) {
       return null;
     }
@@ -41,7 +41,7 @@ export class #{CrudServiceClassName} {
     data: Prisma.#{Model}UpdateInput,
   ): Promise<#{Model} | null> {
     try {
-      return await this.prismaService.#{model}.update({
+      return await this.prismaService.#{moDel}.update({
         where: { id: id },
         data: data,
       });
@@ -52,7 +52,7 @@ export class #{CrudServiceClassName} {
 
   async delete(id: string): Promise<#{Model} | null> {
     try {
-      return await this.prismaService.#{model}.delete({ where: { id: id } });
+      return await this.prismaService.#{moDel}.delete({ where: { id: id } });
     } catch (e) {
       return null;
     }
@@ -60,7 +60,7 @@ export class #{CrudServiceClassName} {
 
   async count(filter?: Prisma.#{Model}CountArgs): Promise<number | null> {
     try {
-      return await this.prismaService.#{model}.count(filter);
+      return await this.prismaService.#{moDel}.count(filter);
     } catch (e) {
       return null;
     }


### PR DESCRIPTION
This PR will close #26 .

It adds a new variable `#{moDel}` that uses the `first letter lower-cased` version of the model name. Also, the stub files are properly updated.