### PR TITLE
feat(prisma-crud-generator): Neverthrow

### DIFF
--- a/libs/prisma-crud-generator/README.md
+++ b/libs/prisma-crud-generator/README.md
@@ -10,6 +10,12 @@ Install the package via
 npm i -D @prisma-utils/prisma-crud-generator
 ```
 
+If you would like to use automatically wrap prisma calls with `Exceptions`, you need to manually install `neverthrow` as well.
+
+```bash
+npm i neverthrow
+```
+
 ## Usage
 
 Open your `prisma.schema` file to add a new `generator`.
@@ -52,6 +58,10 @@ Additionally, the `prisma-crud-generator` also offers specific configuration par
 | CRUDServiceSuffix | string  | "CrudService" | Suffix that is appended to the name of the model.                                         |
 | CRUDStubFile      | string  | undefined     | (optional) path to a custom stub-file to read the template from.                          |
 | CRUDAddExceptions | boolean | true          | Whether prisma calls should be wrapped in an exception or not (by default it is wrapped)  |
+
+### Exceptions
+
+Using the `CRUDAddExceptions` feature (i.e., set to `true`) will wrap the `result` (i.e., data returned by prisma or an error) in a `Result` object from `neverthrow`. For a basic usage, see the [wiki of `neverthrow`](https://github.com/supermacro/neverthrow/wiki/Basic-Usage-Examples).
 
 ### CRUD Service Stub File
 

--- a/libs/prisma-crud-generator/src/stubs/crud.service.stub.ts
+++ b/libs/prisma-crud-generator/src/stubs/crud.service.stub.ts
@@ -26,23 +26,28 @@ export class #{CrudServiceClassName} {
   async getAll(
     filter?: Prisma.#{Model}FindManyArgs,
   ): Promise<PaginationInterface<#{Model}>> {
-    const [items, count] = await this.prismaService.$transaction([
-      this.prismaService.#{moDel}.findMany(filter),
-      this.prismaService.#{moDel}.count({ where: filter?.where }),
-    ]);
+    try {
+      const [items, count] = await this.prismaService.$transaction([
+        this.prismaService.#{moDel}.findMany(filter),
+        this.prismaService.#{moDel}.count({ where: filter?.where }),
+      ]);
 
-    const take = filter?.take ? filter?.take : count;
-    const skip = filter?.skip ? filter?.skip : 0;
+      const take = filter?.take ? filter?.take : count;
+      const skip = filter?.skip ? filter?.skip : 0;
 
-    return {
-      items: items,
-      meta: {
-        totalItems: count,
-        items: items.length,
-        totalPages: Math.ceil(count / take),
-        page: skip / take + 1,
-      },
-    };
+      return {
+        items: items,
+        meta: {
+          totalItems: count,
+          items: items.length,
+          totalPages: Math.ceil(count / take),
+          page: skip / take + 1,
+        },
+      };
+    }
+    catch(e) {
+      throw new InternalServerErrorException(\`Could not get #{Model} Resources.\`);
+    }
   }
 
   async getById(id: string): Promise<#{Model}> {
@@ -61,7 +66,7 @@ export class #{CrudServiceClassName} {
       const result = await this.prismaService.#{moDel}.create({ data: data });
       return result;
     } catch (e) {
-      throw new InternalServerErrorException(\`Could not create #{Model} Resource\`);
+      throw new InternalServerErrorException(\`Could not create #{Model} Resource.\`);
     }
   }
 
@@ -76,7 +81,7 @@ export class #{CrudServiceClassName} {
       });
     } catch (e) {
       throw new InternalServerErrorException(
-        \`Could not update #{Model} Resource \${id}\`,
+        \`Could not update #{Model} Resource \${id}.\`,
       );
     }
   }
@@ -86,7 +91,7 @@ export class #{CrudServiceClassName} {
       return await this.prismaService.#{moDel}.delete({ where: { id: id } });
     } catch (e) {
       throw new InternalServerErrorException(
-        \`Could not delete #{Model} Model \${id}\`,
+        \`Could not delete #{Model} Model \${id}.\`,
       );
     }
   }


### PR DESCRIPTION
This PR adds `neverthrow` to the crud stubs to handle exceptions.
This leads to the fact, that exceptions will **not** be handled anymore by the service itself, but rather be wrapped in a `Result` object that is passed back to the callee. The application designer (i.e., you!) can decide what to do next.