### PR TITLE
[Feat]: Filter for Request Parser

### DIFF
--- a/apps/api/src/app/app.controller.spec.ts
+++ b/apps/api/src/app/app.controller.spec.ts
@@ -24,6 +24,7 @@ describe('AppController', () => {
           skip: 0,
           sort: [],
           take: 10,
+          filter: {},
         }),
       ).toEqual({ message: 'Welcome to api!' });
     });

--- a/apps/api/src/app/app.controller.ts
+++ b/apps/api/src/app/app.controller.ts
@@ -11,7 +11,8 @@ export class AppController {
   constructor(private readonly appService: AppService) {}
 
   @Get()
-  getData(@RequestParser() foo: ParsedQueryModel) {
+  getData(@RequestParser() params: ParsedQueryModel) {
+    console.log(params);
     return this.appService.getData();
   }
 

--- a/libs/request-parser/README.md
+++ b/libs/request-parser/README.md
@@ -22,18 +22,25 @@ export class UserController {
 Then call the route as follows:
 
 ```bash
-example.com/api/users?sort=-id,name&limit=20&page=5
+example.com/api/users?sort=-id,name&limit=20&page=5&filter={"email": {"endsWith": "googlemail.com"}}
 ```
 
-will return 20 entries from the 5th page (i.e., entry 81 - 100). Entries are ordered by id (descending) and name (ascending).
+will return users with an email address that ends with `googlemail.com`. The route will return 20 entries from the 5th page (i.e., entry 81 - 100). Entries are ordered by id (descending) and name (ascending).
 
 ### Query Parameter Schema
 
-| name  | description                                                                                                                                | default |
-| ----- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
-| sort  | `order by` attribute. Comma separated list of attributes. `-` in front of a attribute (i.e., `-id`) means order by attribute `descending`. | `id`    |
-| limit | `limit` the result to a specific number of entries. Provides the possibility to set a maximum value as well                                | 20      |
-| page  | describe the page that should be retrieved (use in combination with `limit`)                                                               | 1       |
+| name     | description                                                                                                                                | default |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| `sort`   | `order by` attribute. Comma separated list of attributes. `-` in front of a attribute (i.e., `-id`) means order by attribute `descending`. | `id`    |
+| `limit`  | `limit` the result to a specific number of entries. Provides the possibility to set a maximum value as well                                | 20      |
+| `page`   | describe the page that should be retrieved (use in combination with `limit`)                                                               | 1       |
+| `filter` | describe an additional filter/where clause that may be appended to the `findX` call.                                                       | `{}`    |
+
+#### Filter
+
+The `filter` parameter should be passed as an object. Please note that this library does not validate / properly parse the passed object. Basically, you are free to use whatever style / format you would like. It would, however, be a good idea to use a similar idea as Prisma does (see the [official documentation](https://www.prisma.io/docs/concepts/components/prisma-client/filtering-and-sorting#filtering)).
+
+The `filter` parameter value must be `JSON.parse`able, otherwise the default value (`{}`) is used.
 
 ### Default Configuration
 
@@ -47,7 +54,10 @@ will return 20 entries from the 5th page (i.e., entry 81 - 100). Entries are ord
   "pageDefaultValue": 1,
 
   "orderParamName": "sort",
-  "orderDefaultValue": "id"
+  "orderDefaultValue": "id",
+
+  "filterParamName": "filter",
+  "filterDefaultValue": {}
 }
 ```
 

--- a/libs/request-parser/src/lib/models/parsed-query.model.ts
+++ b/libs/request-parser/src/lib/models/parsed-query.model.ts
@@ -3,6 +3,7 @@ export interface ParsedQueryModel {
   skip: number;
   take: number;
   sort: ParsedQuerySortModel[];
+  filter: object;
 }
 
 export interface ParsedQuerySortModel {

--- a/libs/request-parser/src/lib/models/request-query.options.ts
+++ b/libs/request-parser/src/lib/models/request-query.options.ts
@@ -8,4 +8,7 @@ export interface RequestQueryOptions {
 
   orderParamName: string;
   orderDefaultValue: string;
+
+  filterParamName: string;
+  filterDefaultValue: object;
 }

--- a/libs/request-parser/src/lib/services/request-parser.service.ts
+++ b/libs/request-parser/src/lib/services/request-parser.service.ts
@@ -11,6 +11,9 @@ const defaultRequestQueryOptions: RequestQueryOptions = {
   limitDefaultValue: 20,
   maxLimit: 100,
 
+  filterParamName: 'filter',
+  filterDefaultValue: {},
+
   pageParamName: 'page',
   pageDefaultValue: 1,
 
@@ -40,19 +43,21 @@ export class RequestParserService {
     const page = this.parsePage();
     const limit = this.parseLimit();
     const sort = this.parseSort();
+    const filter = this.parseFilter();
 
     return {
       page: page,
       skip: this.calculateSkip(page, limit),
       take: limit,
       sort: sort,
+      filter: filter,
     };
   }
 
   private parsePage(): number {
-    const pageParam = this.query[this.options.pageParamName];
+    const pageRequestData = this.query[this.options.pageParamName];
 
-    const page = parseInt(pageParam) || this.options.pageDefaultValue;
+    const page = parseInt(pageRequestData) || this.options.pageDefaultValue;
 
     if (page < 1) {
       return this.options.pageDefaultValue;
@@ -62,9 +67,9 @@ export class RequestParserService {
   }
 
   private parseLimit(): number {
-    const limitParam = this.query[this.options.limitParamName];
+    const limitRequestData = this.query[this.options.limitParamName];
 
-    let limit = parseInt(limitParam) || this.options.limitDefaultValue;
+    let limit = parseInt(limitRequestData) || this.options.limitDefaultValue;
 
     if (limit < 1) {
       limit = this.options.limitDefaultValue;
@@ -81,13 +86,28 @@ export class RequestParserService {
     return (page - 1) * limit;
   }
 
+  private parseFilter(): object {
+    let filter: object = {};
+
+    const filterRequestData =
+      this.query[this.options.filterParamName] ||
+      this.options.filterDefaultValue;
+
+    try {
+      filter = JSON.parse(filterRequestData);
+    } catch (e) {
+      return filter;
+    }
+    return filter;
+  }
+
   private parseSort(): ParsedQuerySortModel[] {
     const sort: ParsedQuerySortModel[] = [];
 
-    const sortParam =
+    const sortRequestData =
       this.query[this.options.orderParamName] || this.options.orderDefaultValue;
 
-    const sortQuery = (sortParam as string).trim();
+    const sortQuery = (sortRequestData as string).trim();
 
     if (sortQuery !== undefined) {
       if (sortQuery.length > 0) {


### PR DESCRIPTION
Allows to pass filter params for the `request-parser` package.

Use it like so:
```bash
GET example.com/users?filter={"id":4711}
GET example.com/users?filter={"foo": true, "bar": {"x": 123, "y": "hello world" } }
```
or any other deeply nested structure.

`filter` accepts an `object` and must be `JSON.parse()`able. Otherwise an empty object (`{}`) is returned.